### PR TITLE
Support mobile touch controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 .tools/
 tests/web-smoke.png
+tests/mobile-smoke.png

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -177,6 +177,7 @@ let pointer: Point = { x: 0, y: 0 };
 let hitZones: HitZone[] = [];
 let battleBannerUntilMs = 0;
 let backpackVisualY = BAG_OPEN_Y;
+let landscapeLockRequested = false;
 const debugWindow = window as typeof window & {
   __backpackDebug?: () => GameSnapshot;
   __backpackDebugForceResult?: (phase?: "victory" | "defeat") => GameSnapshot;
@@ -199,12 +200,14 @@ syncCanvasScale();
 preloadSprites();
 
 canvas.addEventListener("pointerdown", (event) => {
+  event.preventDefault();
+  requestLandscapeViewport();
   pointer = pointerFromEvent(event);
 
   const item = itemAt(pointer.x, pointer.y);
   if (item && state.phase === "draft") {
     draggingItemId = item.instance.id;
-    canvas.setPointerCapture(event.pointerId);
+    capturePointer(event.pointerId);
     return;
   }
 
@@ -216,10 +219,12 @@ canvas.addEventListener("pointerdown", (event) => {
 });
 
 canvas.addEventListener("pointermove", (event) => {
+  event.preventDefault();
   pointer = pointerFromEvent(event);
 });
 
 canvas.addEventListener("pointerup", (event) => {
+  event.preventDefault();
   pointer = pointerFromEvent(event);
   if (draggingItemId) {
     const cell = pointerToCell(pointer.x, pointer.y);
@@ -232,9 +237,19 @@ canvas.addEventListener("pointerup", (event) => {
       });
     }
     draggingItemId = null;
-    canvas.releasePointerCapture(event.pointerId);
+    releasePointer(event.pointerId);
     render();
   }
+});
+
+canvas.addEventListener("pointercancel", (event) => {
+  event.preventDefault();
+  draggingItemId = null;
+  releasePointer(event.pointerId);
+});
+
+canvas.addEventListener("contextmenu", (event) => {
+  event.preventDefault();
 });
 
 window.addEventListener("resize", () => {
@@ -653,6 +668,35 @@ function restartRun(): void {
   state = dispatchCommand(state, { type: "restart", seed: randomSeed() });
   paused = false;
   backpackVisualY = BAG_OPEN_Y;
+}
+
+function capturePointer(pointerId: number): void {
+  try {
+    canvas.setPointerCapture(pointerId);
+  } catch {
+    // Synthetic mobile smoke tests do not create a browser-level active pointer.
+  }
+}
+
+function releasePointer(pointerId: number): void {
+  try {
+    if (canvas.hasPointerCapture(pointerId)) {
+      canvas.releasePointerCapture(pointerId);
+    }
+  } catch {
+    // Pointer capture may already be gone after touch cancellation.
+  }
+}
+
+function requestLandscapeViewport(): void {
+  if (landscapeLockRequested || !window.matchMedia("(pointer: coarse)").matches) {
+    return;
+  }
+  landscapeLockRequested = true;
+  const orientation = screen.orientation as ScreenOrientation & {
+    lock?: (orientation: OrientationLockType) => Promise<void>;
+  };
+  void orientation.lock?.("landscape").catch(() => undefined);
 }
 
 function drawBattleLedger(): void {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -2,9 +2,16 @@ html,
 body {
   width: 100%;
   height: 100%;
+  height: 100dvh;
   margin: 0;
   overflow: hidden;
   background: #0b0f12;
+  overscroll-behavior: none;
+  touch-action: none;
+  -webkit-text-size-adjust: 100%;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 body {
@@ -16,14 +23,25 @@ body {
     BlinkMacSystemFont,
     "Segoe UI",
     sans-serif;
+  position: fixed;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
+    env(safe-area-inset-left);
 }
 
 #game {
   display: block;
   width: min(100vw, calc(100vh * 1280 / 760));
   height: min(100vh, calc(100vw * 760 / 1280));
+  width: min(100dvw, calc(100dvh * 1280 / 760));
+  height: min(100dvh, calc(100dvw * 760 / 1280));
+  max-width: 100vw;
+  max-height: 100vh;
   background: #0b0f12;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,12 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <title>背包构筑自动战斗</title>
     <link rel="icon" type="image/png" href="/assets/sprites/ui/reward_chest.png" />
     <link rel="apple-touch-icon" href="/assets/sprites/ui/reward_chest.png" />

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vp preview --host 127.0.0.1",
     "check": "vp check",
     "test": "node --test packages/core/src/engine.test.ts",
+    "test:mobile": "node tests/mobile-smoke.mjs",
     "sim": "node apps/sim/src/main.ts"
   },
   "devDependencies": {

--- a/tests/mobile-smoke.mjs
+++ b/tests/mobile-smoke.mjs
@@ -1,0 +1,133 @@
+const playwrightModule =
+  process.env.PLAYWRIGHT_MODULE ??
+  "/Users/zuozijian/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules/playwright/index.mjs";
+
+const { chromium } = await import(playwrightModule);
+
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 844, height: 390 },
+  deviceScaleFactor: 2,
+  isMobile: true,
+  hasTouch: true,
+});
+const page = await context.newPage();
+const errors = [];
+page.on("pageerror", (error) => errors.push(error.message));
+page.on("console", (message) => {
+  if (message.type() === "error") {
+    errors.push(message.text());
+  }
+});
+
+await page.goto(process.env.WEB_SMOKE_URL ?? "http://127.0.0.1:5173", { waitUntil: "networkidle" });
+await page.waitForSelector("#game");
+
+async function logicalPoint(x, y) {
+  return page.$eval(
+    "#game",
+    (canvas, point) => {
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: rect.left + (point.x / 1280) * rect.width,
+        y: rect.top + (point.y / 760) * rect.height,
+      };
+    },
+    { x, y },
+  );
+}
+
+async function pointer(type, x, y, buttons = 1) {
+  const point = await logicalPoint(x, y);
+  await page.$eval(
+    "#game",
+    (canvas, eventInit) => {
+      canvas.dispatchEvent(
+        new PointerEvent(eventInit.type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId: 7,
+          pointerType: "touch",
+          isPrimary: true,
+          clientX: eventInit.x,
+          clientY: eventInit.y,
+          buttons: eventInit.buttons,
+        }),
+      );
+    },
+    { type, x: point.x, y: point.y, buttons },
+  );
+}
+
+async function tap(x, y) {
+  await pointer("pointerdown", x, y, 1);
+  await pointer("pointerup", x, y, 0);
+}
+
+async function drag(fromX, fromY, toX, toY) {
+  await pointer("pointerdown", fromX, fromY, 1);
+  for (let step = 1; step <= 8; step += 1) {
+    const ratio = step / 8;
+    await pointer("pointermove", fromX + (toX - fromX) * ratio, fromY + (toY - fromY) * ratio, 1);
+  }
+  await pointer("pointerup", toX, toY, 0);
+}
+
+await tap(336, 140);
+await drag(521, 445, 753, 619);
+const draftSnapshot = await page.evaluate(() => window.__backpackDebug?.());
+if (!draftSnapshot?.items.some((item) => item.instance.x === 4 && item.instance.y === 4)) {
+  throw new Error(
+    `Expected touch drag to land in bottom-right cell: ${JSON.stringify(draftSnapshot)}`,
+  );
+}
+await tap(754, 693);
+await page.waitForTimeout(500);
+
+const metrics = await page.evaluate(() => {
+  const canvas = document.querySelector("#game");
+  if (!(canvas instanceof HTMLCanvasElement)) {
+    throw new Error("Missing canvas.");
+  }
+  const viewport = document.querySelector('meta[name="viewport"]')?.getAttribute("content") ?? "";
+  const computedCanvas = getComputedStyle(canvas);
+  const computedBody = getComputedStyle(document.body);
+  return {
+    width: canvas.width,
+    height: canvas.height,
+    viewport,
+    canvasTouchAction: computedCanvas.touchAction,
+    bodyTouchAction: computedBody.touchAction,
+    bodyOverflow: computedBody.overflow,
+  };
+});
+const snapshot = await page.evaluate(() => window.__backpackDebug?.());
+
+await page.screenshot({ path: "tests/mobile-smoke.png", fullPage: true });
+await context.close();
+await browser.close();
+
+if (errors.length > 0) {
+  throw new Error(`Browser errors:\n${errors.join("\n")}`);
+}
+if (
+  !metrics.viewport.includes("user-scalable=no") ||
+  !metrics.viewport.includes("maximum-scale=1")
+) {
+  throw new Error(`Viewport zoom is not disabled: ${JSON.stringify(metrics)}`);
+}
+if (
+  metrics.canvasTouchAction !== "none" ||
+  metrics.bodyTouchAction !== "none" ||
+  metrics.bodyOverflow !== "hidden"
+) {
+  throw new Error(`Unexpected mobile touch CSS: ${JSON.stringify(metrics)}`);
+}
+if (metrics.width < 1280 || metrics.height < 760) {
+  throw new Error(`Unexpected canvas backing size: ${JSON.stringify(metrics)}`);
+}
+if (!snapshot || snapshot.phase !== "battle" || snapshot.tick <= 0) {
+  throw new Error(`Expected battle after touch reward and start: ${JSON.stringify(snapshot)}`);
+}
+
+console.log(JSON.stringify({ ...metrics, phase: snapshot.phase, tick: snapshot.tick }));


### PR DESCRIPTION
Closes #14

## Summary
- disable page zoom/scroll gestures for the game viewport
- handle touch pointer drag/cancel safely on the canvas
- add a mobile smoke test that verifies touch drag, disabled zoom, and battle start

## Tests
- vp check
- node --test packages/core/src/engine.test.ts
- node tests/web-smoke.mjs
- node tests/mobile-smoke.mjs
- vp build
- git diff --check